### PR TITLE
Remove use of `python-dotenv` and loosen dependencies

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -53,7 +53,7 @@ postgres_upsert(table, conn, keys, data_iter)
 
 ## Environment Configuration
 
-The package requires several environment variables to be set in a `.env` file:
+This package depends on the following environment variables:
 
 ```bash
 # Development Environment

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,7 +31,7 @@ pip install -e ".[dev]"
 
 ## Environment Configuration
 
-Create a `.env` file in your project root:
+This package depends on the following environment variables:
 
 ```bash
 # Development Environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,14 +28,14 @@ classifiers = [
 ]
 
 dependencies = [
-    "geopandas==1.0.1",
+    "geopandas>=1.0.1",
     "pandas>=2.2.2",
-    "rioxarray==0.17.0",
-    "xarray==2024.7.0",
-    "azure-storage-blob==12.22.0",
-    "sqlalchemy==2.0.36",
-    "psycopg2-binary==2.9.10",
-    "pyarrow==19.0.0",
+    "rioxarray>=0.17.0",
+    "xarray>=2024.7.0",
+    "azure-storage-blob>=12.22.0",
+    "sqlalchemy>=2.0.36",
+    "psycopg2-binary>=2.9.10",
+    "pyarrow>=19.0.0",
     "dask>2024.8.0",
     "Jinja2>=3.1.6"
 ]
@@ -43,9 +43,9 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = [
-    "ruff==0.9.6",
-    "pre-commit==3.8.0",
-    "python-dotenv==1.0.1",
+    "ruff>=0.9.6",
+    "pre-commit>=3.8.0",
+    "python-dotenv>=1.0.1",
     "pytest"
 ]
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
     "psycopg2-binary==2.9.10",
     "pyarrow==19.0.0",
     "dask==2024.8.0",
-    "python-dotenv==1.0.1"
 ]
 dynamic = ["version"]
 
@@ -45,6 +44,7 @@ dynamic = ["version"]
 dev = [
     "ruff==0.9.6",
     "pre-commit==3.8.0",
+    "python-dotenv==1.0.1",
     "pytest"
 ]
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,14 +29,15 @@ classifiers = [
 
 dependencies = [
     "geopandas==1.0.1",
-    "pandas==2.2.3",
+    "pandas>=2.2.2",
     "rioxarray==0.17.0",
     "xarray==2024.7.0",
     "azure-storage-blob==12.22.0",
     "sqlalchemy==2.0.36",
     "psycopg2-binary==2.9.10",
     "pyarrow==19.0.0",
-    "dask==2024.8.0",
+    "dask>2024.8.0",
+    "Jinja2>=3.1.6"
 ]
 dynamic = ["version"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ cloudpickle==3.1.1
     # via dask
 cryptography==44.0.2
     # via azure-storage-blob
-dask==2024.8.0
+dask==2025.3.0
     # via ocha-stratus (pyproject.toml)
 distlib==0.3.9
     # via virtualenv
@@ -68,6 +68,7 @@ isodate==0.7.2
     # via azure-storage-blob
 jinja2==3.1.6
     # via
+    #   ocha-stratus (pyproject.toml)
     #   myst-parser
     #   sphinx
 locket==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ affine==2.4.0
     # via rasterio
 alabaster==1.0.0
     # via sphinx
-attrs==25.1.0
+attrs==25.3.0
     # via rasterio
 azure-core==1.32.0
     # via azure-storage-blob
@@ -38,7 +38,7 @@ cligj==0.7.2
     # via rasterio
 cloudpickle==3.1.1
     # via dask
-cryptography==44.0.1
+cryptography==44.0.2
     # via azure-storage-blob
 dask==2024.8.0
     # via ocha-stratus (pyproject.toml)
@@ -48,25 +48,25 @@ docutils==0.21.2
     # via
     #   myst-parser
     #   sphinx
-filelock==3.17.0
+filelock==3.18.0
     # via virtualenv
-fsspec==2025.2.0
+fsspec==2025.3.0
     # via dask
 furo==2024.8.6
     # via ocha-stratus (pyproject.toml)
 geopandas==1.0.1
     # via ocha-stratus (pyproject.toml)
-identify==2.6.8
+identify==2.6.9
     # via pre-commit
 idna==3.10
     # via requests
 imagesize==1.4.1
     # via sphinx
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via pytest
 isodate==0.7.2
     # via azure-storage-blob
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   myst-parser
     #   sphinx
@@ -86,7 +86,7 @@ myst-parser==4.0.1
     # via ocha-stratus (pyproject.toml)
 nodeenv==1.9.1
     # via pre-commit
-numpy==2.2.3
+numpy==2.2.4
     # via
     #   geopandas
     #   pandas
@@ -111,7 +111,7 @@ pandas==2.2.3
     #   xarray
 partd==1.4.2
     # via dask
-platformdirs==4.3.6
+platformdirs==4.3.7
     # via virtualenv
 pluggy==1.5.0
     # via pytest
@@ -129,13 +129,13 @@ pygments==2.19.1
     #   sphinx
 pyogrio==0.10.0
     # via geopandas
-pyparsing==3.2.1
+pyparsing==3.2.2
     # via rasterio
 pyproj==3.7.1
     # via
     #   geopandas
     #   rioxarray
-pytest==8.3.4
+pytest==8.3.5
     # via ocha-stratus (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via pandas
@@ -170,7 +170,7 @@ snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.6
     # via beautifulsoup4
-sphinx==8.2.1
+sphinx==8.2.3
     # via
     #   ocha-stratus (pyproject.toml)
     #   furo
@@ -205,11 +205,11 @@ typing-extensions==4.12.2
     #   azure-storage-blob
     #   beautifulsoup4
     #   sqlalchemy
-tzdata==2025.1
+tzdata==2025.2
     # via pandas
 urllib3==2.3.0
     # via requests
-virtualenv==20.29.2
+virtualenv==20.29.3
     # via pre-commit
 xarray==2024.7.0
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ attrs==25.3.0
     # via rasterio
 azure-core==1.32.0
     # via azure-storage-blob
-azure-storage-blob==12.22.0
+azure-storage-blob==12.25.0
     # via ocha-stratus (pyproject.toml)
 babel==2.17.0
     # via sphinx
@@ -116,11 +116,11 @@ platformdirs==4.3.7
     # via virtualenv
 pluggy==1.5.0
     # via pytest
-pre-commit==3.8.0
+pre-commit==4.2.0
     # via ocha-stratus (pyproject.toml)
 psycopg2-binary==2.9.10
     # via ocha-stratus (pyproject.toml)
-pyarrow==19.0.0
+pyarrow==19.0.1
     # via ocha-stratus (pyproject.toml)
 pycparser==2.22
     # via cffi
@@ -155,11 +155,11 @@ requests==2.32.3
     # via
     #   azure-core
     #   sphinx
-rioxarray==0.17.0
+rioxarray==0.18.2
     # via ocha-stratus (pyproject.toml)
 roman-numerals-py==3.1.0
     # via sphinx
-ruff==0.9.6
+ruff==0.11.2
     # via ocha-stratus (pyproject.toml)
 shapely==2.0.7
     # via geopandas
@@ -194,7 +194,7 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.36
+sqlalchemy==2.0.39
     # via ocha-stratus (pyproject.toml)
 toolz==1.0.0
     # via
@@ -212,7 +212,7 @@ urllib3==2.3.0
     # via requests
 virtualenv==20.29.3
     # via pre-commit
-xarray==2024.7.0
+xarray==2025.3.0
     # via
     #   ocha-stratus (pyproject.toml)
     #   rioxarray

--- a/src/ocha_stratus/azure_blob.py
+++ b/src/ocha_stratus/azure_blob.py
@@ -10,9 +10,6 @@ import pandas as pd
 import rioxarray as rxr
 import xarray as xr
 from azure.storage.blob import ContainerClient, ContentSettings
-from dotenv import load_dotenv
-
-load_dotenv()
 
 PROD_BLOB_SAS = os.getenv("DSCI_AZ_BLOB_PROD_SAS")
 DEV_BLOB_SAS = os.getenv("DSCI_AZ_BLOB_DEV_SAS")

--- a/src/ocha_stratus/azure_database.py
+++ b/src/ocha_stratus/azure_database.py
@@ -1,11 +1,8 @@
 import os
 from typing import Literal
 
-from dotenv import load_dotenv
 from sqlalchemy import create_engine
 from sqlalchemy.dialects.postgresql import insert
-
-load_dotenv()
 
 AZURE_DB_PW_DEV = os.getenv("DSCI_AZ_DB_DEV_PW")
 AZURE_DB_PW_PROD = os.getenv("DSCI_AZ_DB_PROD_PW")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 import pytest
 
 
@@ -21,7 +19,3 @@ def mock_env_vars(monkeypatch):
     # Use monkeypatch instead of directly modifying os.environ
     for key, value in env_vars.items():
         monkeypatch.setenv(key, value)
-
-    # Mock dotenv.load_dotenv to do nothing
-    with patch("dotenv.load_dotenv"):
-        yield

--- a/tests/test_azure_blob.py
+++ b/tests/test_azure_blob.py
@@ -29,129 +29,116 @@ def sample_xarray():
 
 def test_get_container_client_read_dev():
     """Test getting a dev container client for reading."""
-    with patch("dotenv.load_dotenv"):
-        from ocha_stratus.azure_blob import get_container_client
+    from ocha_stratus.azure_blob import get_container_client
 
-        with patch("ocha_stratus.azure_blob.ContainerClient") as mock:
-            get_container_client(stage="dev", write=False)
-            mock.from_container_url.assert_called_once()
-            url = mock.from_container_url.call_args[0][0]
-            assert "dev" in url
-            assert "fake-dev-sas" in url  # Regular SAS token
-            assert "fake-dev-sas-write" not in url  # Not using write token
+    with patch("ocha_stratus.azure_blob.ContainerClient") as mock:
+        get_container_client(stage="dev", write=False)
+        mock.from_container_url.assert_called_once()
+        url = mock.from_container_url.call_args[0][0]
+        assert "dev" in url
+        assert "fake-dev-sas" in url  # Regular SAS token
+        assert "fake-dev-sas-write" not in url  # Not using write token
 
 
 def test_get_container_client_write_dev():
     """Test getting a dev container client for writing."""
-    with patch("dotenv.load_dotenv"):
-        from ocha_stratus.azure_blob import get_container_client
+    from ocha_stratus.azure_blob import get_container_client
 
-        with patch("ocha_stratus.azure_blob.ContainerClient") as mock:
-            get_container_client(stage="dev", write=True)
-            mock.from_container_url.assert_called_once()
-            url = mock.from_container_url.call_args[0][0]
-            assert "dev" in url
-            assert "fake-dev-sas-write" in url  # Using write token
+    with patch("ocha_stratus.azure_blob.ContainerClient") as mock:
+        get_container_client(stage="dev", write=True)
+        mock.from_container_url.assert_called_once()
+        url = mock.from_container_url.call_args[0][0]
+        assert "dev" in url
+        assert "fake-dev-sas-write" in url  # Using write token
 
 
 def test_get_container_client_prod():
     """Test getting a prod container client."""
-    with patch("dotenv.load_dotenv"):
-        from ocha_stratus.azure_blob import get_container_client
+    from ocha_stratus.azure_blob import get_container_client
 
-        with patch("ocha_stratus.azure_blob.ContainerClient") as mock:
-            get_container_client(stage="prod")
-            mock.from_container_url.assert_called_once()
-            url = mock.from_container_url.call_args[0][0]
-            assert "prod" in url
-            assert "fake-prod-sas" in url
+    with patch("ocha_stratus.azure_blob.ContainerClient") as mock:
+        get_container_client(stage="prod")
+        mock.from_container_url.assert_called_once()
+        url = mock.from_container_url.call_args[0][0]
+        assert "prod" in url
+        assert "fake-prod-sas" in url
 
 
 def test_get_container_client_invalid_stage():
     """Test getting a container client with invalid stage."""
-    with patch("dotenv.load_dotenv"):
-        from ocha_stratus.azure_blob import get_container_client
+    from ocha_stratus.azure_blob import get_container_client
 
-        with pytest.raises(ValueError):
-            get_container_client(stage="invalid")
+    with pytest.raises(ValueError):
+        get_container_client(stage="invalid")
 
 
 def test_upload_parquet_to_blob(mock_container_client, sample_dataframe):
     """Test uploading a parquet file to blob storage."""
-    with patch("dotenv.load_dotenv"):
-        from ocha_stratus.azure_blob import upload_parquet_to_blob
+    from ocha_stratus.azure_blob import upload_parquet_to_blob
 
-        blob_name = "test.parquet"
-        upload_parquet_to_blob(sample_dataframe, blob_name, stage="dev")
-        mock_container_client.get_blob_client.assert_called_once_with(
-            blob_name
-        )
-        mock_container_client.get_blob_client.return_value.upload_blob.assert_called_once()
+    blob_name = "test.parquet"
+    upload_parquet_to_blob(sample_dataframe, blob_name, stage="dev")
+    mock_container_client.get_blob_client.assert_called_once_with(blob_name)
+    mock_container_client.get_blob_client.return_value.upload_blob.assert_called_once()
 
 
 def test_load_parquet_from_blob(mock_container_client, sample_dataframe):
     """Test loading a parquet file from blob storage."""
-    with patch("dotenv.load_dotenv"):
-        from ocha_stratus.azure_blob import load_parquet_from_blob
+    from ocha_stratus.azure_blob import load_parquet_from_blob
 
-        # Create parquet data
-        parquet_data = sample_dataframe.to_parquet()
-        mock_container_client.get_blob_client.return_value.download_blob.return_value.readall.return_value = parquet_data
+    # Create parquet data
+    parquet_data = sample_dataframe.to_parquet()
+    mock_container_client.get_blob_client.return_value.download_blob.return_value.readall.return_value = parquet_data
 
-        # Load data
-        result = load_parquet_from_blob("test.parquet", stage="dev")
-        pd.testing.assert_frame_equal(result, sample_dataframe)
+    # Load data
+    result = load_parquet_from_blob("test.parquet", stage="dev")
+    pd.testing.assert_frame_equal(result, sample_dataframe)
 
 
 def test_upload_csv_to_blob(mock_container_client, sample_dataframe):
     """Test uploading a CSV file to blob storage."""
-    with patch("dotenv.load_dotenv"):
-        from ocha_stratus.azure_blob import upload_csv_to_blob
+    from ocha_stratus.azure_blob import upload_csv_to_blob
 
-        blob_name = "test.csv"
-        upload_csv_to_blob(sample_dataframe, blob_name, stage="dev")
-        mock_container_client.get_blob_client.assert_called_once_with(
-            blob_name
-        )
-        mock_container_client.get_blob_client.return_value.upload_blob.assert_called_once()
+    blob_name = "test.csv"
+    upload_csv_to_blob(sample_dataframe, blob_name, stage="dev")
+    mock_container_client.get_blob_client.assert_called_once_with(blob_name)
+    mock_container_client.get_blob_client.return_value.upload_blob.assert_called_once()
 
 
 def test_load_csv_from_blob(mock_container_client, sample_dataframe):
     """Test loading a CSV file from blob storage."""
-    with patch("dotenv.load_dotenv"):
-        from ocha_stratus.azure_blob import load_csv_from_blob
+    from ocha_stratus.azure_blob import load_csv_from_blob
 
-        # Create CSV data
-        csv_data = sample_dataframe.to_csv(index=False).encode()
-        mock_container_client.get_blob_client.return_value.download_blob.return_value.readall.return_value = csv_data
+    # Create CSV data
+    csv_data = sample_dataframe.to_csv(index=False).encode()
+    mock_container_client.get_blob_client.return_value.download_blob.return_value.readall.return_value = csv_data
 
-        # Load data
-        result = load_csv_from_blob("test.csv", stage="dev")
-        pd.testing.assert_frame_equal(result, sample_dataframe)
+    # Load data
+    result = load_csv_from_blob("test.csv", stage="dev")
+    pd.testing.assert_frame_equal(result, sample_dataframe)
 
 
 def test_upload_cog_to_blob(sample_xarray):
     """Test uploading a COG to blob storage uses write SAS token."""
-    with patch("dotenv.load_dotenv"):
-        with patch(
-            "ocha_stratus.azure_blob.get_container_client"
-        ) as mock_get_client:
-            mock_client = MagicMock()
-            mock_blob_client = MagicMock()
-            mock_client.get_blob_client.return_value = mock_blob_client
-            mock_get_client.return_value = mock_client
+    with patch(
+        "ocha_stratus.azure_blob.get_container_client"
+    ) as mock_get_client:
+        mock_client = MagicMock()
+        mock_blob_client = MagicMock()
+        mock_client.get_blob_client.return_value = mock_blob_client
+        mock_get_client.return_value = mock_client
 
-            # Mock the necessary methods
-            with (
-                patch("tempfile.NamedTemporaryFile"),
-                patch("builtins.open"),
-                patch("xarray.DataArray.rio.to_raster"),
-            ):
-                from ocha_stratus.azure_blob import upload_cog_to_blob
+        # Mock the necessary methods
+        with (
+            patch("tempfile.NamedTemporaryFile"),
+            patch("builtins.open"),
+            patch("xarray.DataArray.rio.to_raster"),
+        ):
+            from ocha_stratus.azure_blob import upload_cog_to_blob
 
-                upload_cog_to_blob(sample_xarray, "test.tif", stage="dev")
+            upload_cog_to_blob(sample_xarray, "test.tif", stage="dev")
 
-                # Verify get_container_client was called with write=True
-                mock_get_client.assert_called_with(
-                    container_name="projects", stage="dev", write=True
-                )
+            # Verify get_container_client was called with write=True
+            mock_get_client.assert_called_with(
+                container_name="projects", stage="dev", write=True
+            )

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -28,39 +28,36 @@ def sample_table():
 
 def test_get_engine_dev():
     """Test getting a dev database engine."""
-    with patch("dotenv.load_dotenv"):
-        # Import get_engine inside the test to avoid early environment loading
-        from ocha_stratus.azure_database import get_engine
+    # Import get_engine inside the test to avoid early environment loading
+    from ocha_stratus.azure_database import get_engine
 
-        with patch("ocha_stratus.azure_database.create_engine") as mock:
-            get_engine(stage="dev")
-            mock.assert_called_once()
-            url = mock.call_args[0][0]
-            assert "dev" in url
-            assert "fake-dev-pw" in url  # Verify the mocked password is used
-            assert "fake-dev-host" in url  # Verify the mocked host is used
-            assert "fake-dev-uid" in url  # Verify the mocked UID is used
+    with patch("ocha_stratus.azure_database.create_engine") as mock:
+        get_engine(stage="dev")
+        mock.assert_called_once()
+        url = mock.call_args[0][0]
+        assert "dev" in url
+        assert "fake-dev-pw" in url  # Verify the mocked password is used
+        assert "fake-dev-host" in url  # Verify the mocked host is used
+        assert "fake-dev-uid" in url  # Verify the mocked UID is used
 
 
 def test_get_engine_prod():
     """Test getting a prod database engine."""
-    with patch("dotenv.load_dotenv"):
-        from ocha_stratus.azure_database import get_engine
+    from ocha_stratus.azure_database import get_engine
 
-        with patch("ocha_stratus.azure_database.create_engine") as mock:
-            get_engine(stage="prod")
-            mock.assert_called_once()
-            url = mock.call_args[0][0]
-            assert "prod" in url
-            assert "fake-prod-pw" in url
-            assert "fake-prod-host" in url
-            assert "fake-prod-uid" in url
+    with patch("ocha_stratus.azure_database.create_engine") as mock:
+        get_engine(stage="prod")
+        mock.assert_called_once()
+        url = mock.call_args[0][0]
+        assert "prod" in url
+        assert "fake-prod-pw" in url
+        assert "fake-prod-host" in url
+        assert "fake-prod-uid" in url
 
 
 def test_get_engine_invalid_stage():
     """Test getting an engine with invalid stage."""
-    with patch("dotenv.load_dotenv"):
-        from ocha_stratus.azure_database import get_engine
+    from ocha_stratus.azure_database import get_engine
 
-        with pytest.raises(ValueError):
-            get_engine(stage="invalid")
+    with pytest.raises(ValueError):
+        get_engine(stage="invalid")


### PR DESCRIPTION
This package shouldn't force the use of `python-dotenv` -- this should be something handled when the package functionality is implemented, giving the use flexibility to manage environment variables as they see fit. Addresses #4 and #6.