### PR TITLE
Stack cogs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2,7 +2,7 @@
 
 ## Azure Blob Storage
 
-The `azure_blob` module provides utilities for working with Azure Blob Storage.
+Utilities for working with Azure Blob Storage.
 
 ### Container Operations
 
@@ -45,9 +45,17 @@ The `azure_blob` module provides utilities for working with Azure Blob Storage.
 
 ## Database Operations
 
-The `database` module provides utilities for working with Azure PostgreSQL databases.
+Utilities for working with Azure PostgreSQL databases.
 
 ```{eval-rst}
 .. autofunction:: ocha_stratus.get_engine
 .. autofunction:: ocha_stratus.postgres_upsert
+```
+
+## Cloud-Optimized GeoTIFF (COG) Operations
+
+Utilities for working with standard COG datasets.
+
+```{eval-rst}
+.. autofunction:: ocha_stratus.stack_cogs
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,6 +51,24 @@ engine = stratus.get_engine(stage="dev")
 stratus.postgres_upsert(table, conn, keys, data_iter)
 ```
 
+### COG Datasets
+
+```python
+import ocha_stratus as stratus
+import pandas as pd
+
+gdf = stratus.load_shp_from_blob(
+    "ds-aa-nga-flooding/raw/codab/nga.shp.zip",
+    shapefile="nga_adm0.shp",
+    stage="dev",
+)
+
+date_range = ["2024-01-01", "2024-02-01", "2024-03-01"]
+ds = stratus.stack_cogs("era5", date_range, "dev", clip_gdf=gdf)
+
+
+```
+
 ## Environment Configuration
 
 This package depends on the following environment variables:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,8 @@ dependencies = [
     "psycopg2-binary>=2.9.10",
     "pyarrow>=17.0.0",
     "dask>2024.8.0",
-    "Jinja2>=3.1.6"
+    "Jinja2>=3.1.6",
+    "tqdm>=4.67.1"
 ]
 dynamic = ["version"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,15 +6,15 @@ alabaster==1.0.0
     # via sphinx
 attrs==25.3.0
     # via rasterio
-azure-core==1.32.0
+azure-core==1.35.0
     # via azure-storage-blob
-azure-storage-blob==12.25.0
+azure-storage-blob==12.25.1
     # via ocha-stratus (pyproject.toml)
 babel==2.17.0
     # via sphinx
-beautifulsoup4==4.13.3
+beautifulsoup4==4.13.4
     # via furo
-certifi==2025.1.31
+certifi==2025.6.15
     # via
     #   pyogrio
     #   pyproj
@@ -24,23 +24,23 @@ cffi==1.17.1
     # via cryptography
 cfgv==3.4.0
     # via pre-commit
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via requests
-click==8.1.8
+click==8.2.1
     # via
     #   click-plugins
     #   cligj
     #   dask
     #   rasterio
-click-plugins==1.1.1
+click-plugins==1.1.1.2
     # via rasterio
 cligj==0.7.2
     # via rasterio
 cloudpickle==3.1.1
     # via dask
-cryptography==44.0.2
+cryptography==45.0.5
     # via azure-storage-blob
-dask==2025.3.0
+dask==2025.5.1
     # via ocha-stratus (pyproject.toml)
 distlib==0.3.9
     # via virtualenv
@@ -50,13 +50,13 @@ docutils==0.21.2
     #   sphinx
 filelock==3.18.0
     # via virtualenv
-fsspec==2025.3.0
+fsspec==2025.5.1
     # via dask
 furo==2024.8.6
     # via ocha-stratus (pyproject.toml)
-geopandas==1.0.1
+geopandas==1.1.1
     # via ocha-stratus (pyproject.toml)
-identify==2.6.9
+identify==2.6.12
     # via pre-commit
 idna==3.10
     # via requests
@@ -87,7 +87,7 @@ myst-parser==4.0.1
     # via ocha-stratus (pyproject.toml)
 nodeenv==1.9.1
     # via pre-commit
-numpy==2.2.4
+numpy==2.3.1
     # via
     #   geopandas
     #   pandas
@@ -96,7 +96,7 @@ numpy==2.2.4
     #   rioxarray
     #   shapely
     #   xarray
-packaging==24.2
+packaging==25.0
     # via
     #   dask
     #   geopandas
@@ -105,30 +105,31 @@ packaging==24.2
     #   rioxarray
     #   sphinx
     #   xarray
-pandas==2.2.3
+pandas==2.3.0
     # via
     #   ocha-stratus (pyproject.toml)
     #   geopandas
     #   xarray
 partd==1.4.2
     # via dask
-platformdirs==4.3.7
+platformdirs==4.3.8
     # via virtualenv
-pluggy==1.5.0
+pluggy==1.6.0
     # via pytest
 pre-commit==4.2.0
     # via ocha-stratus (pyproject.toml)
 psycopg2-binary==2.9.10
     # via ocha-stratus (pyproject.toml)
-pyarrow==19.0.1
+pyarrow==20.0.0
     # via ocha-stratus (pyproject.toml)
 pycparser==2.22
     # via cffi
-pygments==2.19.1
+pygments==2.19.2
     # via
     #   furo
+    #   pytest
     #   sphinx
-pyogrio==0.10.0
+pyogrio==0.11.0
     # via geopandas
 pyparsing==3.2.3
     # via rasterio
@@ -136,11 +137,11 @@ pyproj==3.7.1
     # via
     #   geopandas
     #   rioxarray
-pytest==8.3.5
+pytest==8.4.1
     # via ocha-stratus (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via pandas
-python-dotenv==1.1.0
+python-dotenv==1.1.1
     # via ocha-stratus (pyproject.toml)
 pytz==2025.2
     # via pandas
@@ -151,25 +152,25 @@ pyyaml==6.0.2
     #   pre-commit
 rasterio==1.4.3
     # via rioxarray
-requests==2.32.3
+requests==2.32.4
     # via
     #   azure-core
     #   sphinx
-rioxarray==0.18.2
+rioxarray==0.19.0
     # via ocha-stratus (pyproject.toml)
 roman-numerals-py==3.1.0
     # via sphinx
-ruff==0.11.2
+ruff==0.12.2
     # via ocha-stratus (pyproject.toml)
-shapely==2.0.7
+shapely==2.1.1
     # via geopandas
 six==1.17.0
     # via
     #   azure-core
     #   python-dateutil
-snowballstemmer==2.2.0
+snowballstemmer==3.0.1
     # via sphinx
-soupsieve==2.6
+soupsieve==2.7
     # via beautifulsoup4
 sphinx==8.2.3
     # via
@@ -194,13 +195,15 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.39
+sqlalchemy==2.0.41
     # via ocha-stratus (pyproject.toml)
 toolz==1.0.0
     # via
     #   dask
     #   partd
-typing-extensions==4.12.2
+tqdm==4.67.1
+    # via ocha-stratus (pyproject.toml)
+typing-extensions==4.14.1
     # via
     #   azure-core
     #   azure-storage-blob
@@ -208,11 +211,11 @@ typing-extensions==4.12.2
     #   sqlalchemy
 tzdata==2025.2
     # via pandas
-urllib3==2.3.0
+urllib3==2.5.0
     # via requests
-virtualenv==20.29.3
+virtualenv==20.31.2
     # via pre-commit
-xarray==2025.3.0
+xarray==2025.7.0
     # via
     #   ocha-stratus (pyproject.toml)
     #   rioxarray

--- a/src/ocha_stratus/__init__.py
+++ b/src/ocha_stratus/__init__.py
@@ -13,6 +13,7 @@ from ocha_stratus.azure_blob import (
     upload_shp_to_blob,
 )
 from ocha_stratus.azure_database import get_engine, postgres_upsert
+from ocha_stratus.cogs import stack_cogs
 
 from ._version import version as __version__  # noqa: F401
 
@@ -33,4 +34,6 @@ __all__ = [
     # Database
     "get_engine",
     "postgres_upsert",
+    # Cogs
+    "stack_cogs",
 ]

--- a/src/ocha_stratus/cogs.py
+++ b/src/ocha_stratus/cogs.py
@@ -1,0 +1,123 @@
+import logging
+import re
+from typing import List, Literal, Union
+
+import pandas as pd
+import tqdm
+import xarray as xr
+
+from .azure_blob import get_container_client, open_blob_cog
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_date(filename):
+    """
+    Parses the date based on a COG filename.
+    """
+    res = re.search("([0-9]{4}-[0-9]{2}-[0-9]{2})", filename)
+    try:
+        output_date = pd.to_datetime(res[0]).strftime("%Y-%m-%d")
+        return output_date
+    except Exception:
+        return None
+
+
+def stack_cogs(
+    dataset: str,
+    dates: Union[List[str], List],
+    stage: str = "prod",
+    mode: Literal["interactive", "pipeline"] = "interactive",
+) -> xr.Dataset:
+    """
+    Stack Cloud Optimized GeoTIFFs (COGs) from Azure Blob Storage into a single xarray Dataset.
+
+    Retrieves and combines multiple COG files for a specified dataset and date range
+    from Azure Blob Storage, returning a unified xarray Dataset with temporal and
+    optional leadtime dimensions.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the dataset to retrieve COGs for. Used as prefix for blob name filtering.
+    dates : List[str] or List
+        Collection of dates to filter COGs by. Should match 'YYYY-MM-DD' format.
+        Will reference the issued date of the dataset (although for non-forecast
+        datasets this is equivalent to the valid date).
+    stage : str, optional
+        Deployment stage for the container client, by default "prod".
+        Determines which Azure storage environment to connect to.
+    mode : {"interactive", "pipeline"}, optional
+        Processing mode, by default "interactive". If "interactive", displays
+        a progress bar using tqdm during processing.
+
+    Returns
+    -------
+    xarray.Dataset
+        Combined dataset with all COGs stacked along temporal dimensions.
+        Contains 'date' dimension and optional 'leadtime' dimension if present
+        in the source data. Attributes from individual COGs are dropped during
+        combination.
+
+    Raises
+    ------
+    Exception
+        If no COGs are found matching the specified dataset and dates.
+
+    Warnings
+    --------
+    Logs a warning if the number of found COGs doesn't match the number of
+    input dates, indicating some requested dates may not have available data.
+
+    Notes
+    -----
+    - Only processes COGs containing "processed" in their filename
+    - Handles both issued and valid date types based on COG metadata
+    - Automatically expands dimensions to include 'date' and 'leadtime' (if present)
+    - Uses `xr.combine_by_coords` to merge datasets, which requires consistent
+    coordinate systems across all input COGs
+    """
+
+    container = get_container_client("raster", stage=stage)
+    cogs_list = [
+        x.name
+        for x in container.list_blobs(name_starts_with=f"{dataset}/")
+        if (_parse_date(x.name) in (dates)) & ("processed" in x.name)
+    ]
+
+    das = []
+    cogs_list = tqdm.tqdm(cogs_list) if mode == "interactive" else cogs_list
+    logger.info(f"Stacking {len(cogs_list)} cogs...")
+
+    if len(cogs_list) != len(dates):
+        logger.warning("Not all COGs available, given input dates")
+    if len(cogs_list) == 0:
+        raise Exception(f"No COGs found to process for dates: {dates}")
+
+    for cog in cogs_list:
+        da_in = open_blob_cog(
+            cog, container_name="raster", container_client=container
+        )
+        date_suffix = (
+            "valid" if da_in.attrs["month_issued"] == "None" else "issued"
+        )
+        year_ = da_in.attrs[f"year_{date_suffix}"]
+        month_ = str(da_in.attrs[f"month_{date_suffix}"]).zfill(2)
+        day_ = (
+            "01"
+            if da_in.attrs["date_valid"] == "None"
+            else da_in.attrs["date_valid"]
+        )
+        date_in = f"{year_}-{month_}-{day_}"
+        da_in = da_in.squeeze(drop=True)
+        da_in["date"] = date_in
+        expand_dims = ["date"]
+        if da_in.attrs["leadtime"] != "None":
+            da_in["leadtime"] = da_in.attrs["leadtime"]
+            expand_dims.append("leadtime")
+        da_in = da_in.expand_dims(expand_dims)
+        da_in = da_in.persist()
+
+        das.append(da_in)
+
+    return xr.combine_by_coords(das, combine_attrs="drop")

--- a/src/ocha_stratus/cogs.py
+++ b/src/ocha_stratus/cogs.py
@@ -26,7 +26,7 @@ def _parse_date(filename):
 
 
 def stack_cogs(
-    dataset: str,
+    dataset: Literal["imerg", "seas5", "era5", "floodscan"],
     dates: Union[List[str], List],
     stage: str = "prod",
     clip_gdf: Optional[gpd.GeoDataFrame] = None,
@@ -41,7 +41,7 @@ def stack_cogs(
 
     Parameters
     ----------
-    dataset : str
+    dataset : {"imerg", "seas5", "era5", "floodscan"}
         Name of the dataset to retrieve COGs for. Used as prefix for blob name filtering.
     dates : List[str] or List
         Collection of dates to filter COGs by. Should match 'YYYY-MM-DD' format.


### PR DESCRIPTION
Closes #10 by basically copying over a simplified version of this function: https://github.com/OCHA-DAP/ds-raster-stats/blob/4b6fc22178624213fc110ad5df4d1da5c64c9e0b/src/utils/cog_utils.py#L128

This new `stack_cogs` function provides the ability to stack cogs of a single dataset based on an input list of dates. These dates don't necessarily have to be consecutive. To keep things simple, I've left out additional band (eg. SFED vs MFED) or leadtime filtering for now, assuming that the user can handle that further on their end. 

Have also slightly modified the handling of `container_clients` in the `load_cog_from_blob` function so that you don't have to instantiate a new client each time you're opening a single COG. 