### PR TITLE
Fix env var import

### DIFF
--- a/src/ocha_stratus/azure_blob.py
+++ b/src/ocha_stratus/azure_blob.py
@@ -11,17 +11,6 @@ import rioxarray as rxr
 import xarray as xr
 from azure.storage.blob import ContainerClient, ContentSettings
 
-PROD_BLOB_SAS = os.getenv("DSCI_AZ_BLOB_PROD_SAS")
-DEV_BLOB_SAS = os.getenv("DSCI_AZ_BLOB_DEV_SAS")
-
-PROD_BLOB_SAS_WRITE = os.getenv("DSCI_AZ_BLOB_PROD_SAS_WRITE")
-DEV_BLOB_SAS_WRITE = os.getenv("DSCI_AZ_BLOB_DEV_SAS_WRITE")
-
-DS_AZ_BLOB_DEV_HOST = "imb0chd0dev.blob.core.windows.net"
-DS_AZ_BLOB_PROD_HOST = "imb0chd0prod.blob.core.windows.net"
-
-AZURE_BLOB_BASE_URL = "https://{host}/{container_name}?{sas}"
-
 
 def get_container_client(
     container_name: str = "projects",
@@ -45,6 +34,17 @@ def get_container_client(
     ContainerClient
         Azure storage container client object
     """
+    PROD_BLOB_SAS = os.getenv("DSCI_AZ_BLOB_PROD_SAS")
+    DEV_BLOB_SAS = os.getenv("DSCI_AZ_BLOB_DEV_SAS")
+
+    PROD_BLOB_SAS_WRITE = os.getenv("DSCI_AZ_BLOB_PROD_SAS_WRITE")
+    DEV_BLOB_SAS_WRITE = os.getenv("DSCI_AZ_BLOB_DEV_SAS_WRITE")
+
+    DS_AZ_BLOB_DEV_HOST = "imb0chd0dev.blob.core.windows.net"
+    DS_AZ_BLOB_PROD_HOST = "imb0chd0prod.blob.core.windows.net"
+
+    AZURE_BLOB_BASE_URL = "https://{host}/{container_name}?{sas}"
+
     if stage == "dev":
         sas_token = DEV_BLOB_SAS_WRITE if write else DEV_BLOB_SAS
         url = AZURE_BLOB_BASE_URL.format(

--- a/src/ocha_stratus/azure_blob.py
+++ b/src/ocha_stratus/azure_blob.py
@@ -44,7 +44,7 @@ def get_container_client(
     DS_AZ_BLOB_PROD_HOST = "imb0chd0prod.blob.core.windows.net"
 
     AZURE_BLOB_BASE_URL = "https://{host}/{container_name}?{sas}"
-
+    print(DS_AZ_BLOB_PROD_HOST)
     if stage == "dev":
         sas_token = DEV_BLOB_SAS_WRITE if write else DEV_BLOB_SAS
         url = AZURE_BLOB_BASE_URL.format(

--- a/src/ocha_stratus/azure_blob.py
+++ b/src/ocha_stratus/azure_blob.py
@@ -44,7 +44,6 @@ def get_container_client(
     DS_AZ_BLOB_PROD_HOST = "imb0chd0prod.blob.core.windows.net"
 
     AZURE_BLOB_BASE_URL = "https://{host}/{container_name}?{sas}"
-    print(DS_AZ_BLOB_PROD_HOST)
     if stage == "dev":
         sas_token = DEV_BLOB_SAS_WRITE if write else DEV_BLOB_SAS
         url = AZURE_BLOB_BASE_URL.format(

--- a/src/ocha_stratus/azure_database.py
+++ b/src/ocha_stratus/azure_database.py
@@ -4,23 +4,6 @@ from typing import Literal
 from sqlalchemy import create_engine
 from sqlalchemy.dialects.postgresql import insert
 
-AZURE_DB_PW_DEV = os.getenv("DSCI_AZ_DB_DEV_PW")
-AZURE_DB_PW_PROD = os.getenv("DSCI_AZ_DB_PROD_PW")
-
-AZURE_DB_PW_DEV_WRITE = os.getenv("DSCI_AZ_DB_DEV_PW_WRITE")
-AZURE_DB_PW_PROD_WRITE = os.getenv("DSCI_AZ_DB_PROD_PW_WRITE")
-
-DS_AZ_DB_DEV_HOST = os.getenv("DSCI_AZ_DB_DEV_HOST")
-DS_AZ_DB_PROD_HOST = os.getenv("DSCI_AZ_DB_PROD_HOST")
-
-AZURE_DB_UID_PROD = os.getenv("DSCI_AZ_DB_PROD_UID")
-AZURE_DB_UID_DEV = os.getenv("DSCI_AZ_DB_DEV_UID")
-
-AZURE_DB_UID_PROD_WRITE = os.getenv("DSCI_AZ_DB_PROD_UID_WRITE")
-AZURE_DB_UID_DEV_WRITE = os.getenv("DSCI_AZ_DB_DEV_UID_WRITE")
-
-AZURE_DB_BASE_URL = "postgresql+psycopg2://{uid}:{pw}@{host}/postgres"
-
 
 def get_engine(stage: Literal["dev", "prod"] = "dev", write: bool = False):
     """
@@ -43,6 +26,23 @@ def get_engine(stage: Literal["dev", "prod"] = "dev", write: bool = False):
     ValueError
         If the provided stage is neither "dev" nor "prod"
     """
+    AZURE_DB_PW_DEV = os.getenv("DSCI_AZ_DB_DEV_PW")
+    AZURE_DB_PW_PROD = os.getenv("DSCI_AZ_DB_PROD_PW")
+
+    AZURE_DB_PW_DEV_WRITE = os.getenv("DSCI_AZ_DB_DEV_PW_WRITE")
+    AZURE_DB_PW_PROD_WRITE = os.getenv("DSCI_AZ_DB_PROD_PW_WRITE")
+
+    DS_AZ_DB_DEV_HOST = os.getenv("DSCI_AZ_DB_DEV_HOST")
+    DS_AZ_DB_PROD_HOST = os.getenv("DSCI_AZ_DB_PROD_HOST")
+
+    AZURE_DB_UID_PROD = os.getenv("DSCI_AZ_DB_PROD_UID")
+    AZURE_DB_UID_DEV = os.getenv("DSCI_AZ_DB_DEV_UID")
+
+    AZURE_DB_UID_PROD_WRITE = os.getenv("DSCI_AZ_DB_PROD_UID_WRITE")
+    AZURE_DB_UID_DEV_WRITE = os.getenv("DSCI_AZ_DB_DEV_UID_WRITE")
+
+    AZURE_DB_BASE_URL = "postgresql+psycopg2://{uid}:{pw}@{host}/postgres"
+
     if stage == "dev":
         if write:
             uid = AZURE_DB_UID_DEV_WRITE

--- a/src/ocha_stratus/azure_database.py
+++ b/src/ocha_stratus/azure_database.py
@@ -42,7 +42,7 @@ def get_engine(stage: Literal["dev", "prod"] = "dev", write: bool = False):
     AZURE_DB_UID_DEV_WRITE = os.getenv("DSCI_AZ_DB_DEV_UID_WRITE")
 
     AZURE_DB_BASE_URL = "postgresql+psycopg2://{uid}:{pw}@{host}/postgres"
-
+    print(DS_AZ_DB_PROD_HOST)
     if stage == "dev":
         if write:
             uid = AZURE_DB_UID_DEV_WRITE

--- a/src/ocha_stratus/azure_database.py
+++ b/src/ocha_stratus/azure_database.py
@@ -42,7 +42,6 @@ def get_engine(stage: Literal["dev", "prod"] = "dev", write: bool = False):
     AZURE_DB_UID_DEV_WRITE = os.getenv("DSCI_AZ_DB_DEV_UID_WRITE")
 
     AZURE_DB_BASE_URL = "postgresql+psycopg2://{uid}:{pw}@{host}/postgres"
-    print(DS_AZ_DB_PROD_HOST)
     if stage == "dev":
         if write:
             uid = AZURE_DB_UID_DEV_WRITE


### PR DESCRIPTION
I had initially set up the environment vars to load when the package was imported, which means that what is most intuitive often doesn't work: 

```
from dotenv import load_dotenv
import ocha_stratus as stratus

load_dotenv()
```

Instead you had to

```
from dotenv import load_dotenv

load_dotenv()

import ocha_stratus as stratus
```

With these changes, the first option should now work.