### PR TITLE
Add listmonk transactional email module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,8 @@ dependencies = [
     "tqdm>=4.67.1",
     "aiohttp>=3.12.15",
     "fsspec>=2025.5.1",
-    "duckdb>=1.4.0"
+    "duckdb>=1.4.0",
+    "requests>=2.32.0"
 ]
 dynamic = ["version"]
 

--- a/src/ocha_stratus/__init__.py
+++ b/src/ocha_stratus/__init__.py
@@ -16,6 +16,7 @@ from ocha_stratus.azure_blob import (
 from ocha_stratus.azure_database import get_engine, postgres_upsert
 from ocha_stratus.cogs import stack_cogs
 from ocha_stratus.datasources import cerf, codab, emdat
+from ocha_stratus.email import listmonk
 
 from ._version import version as __version__  # noqa: F401
 
@@ -43,4 +44,6 @@ __all__ = [
     "codab",
     "cerf",
     "emdat",
+    # Email
+    "listmonk",
 ]

--- a/src/ocha_stratus/email/listmonk.py
+++ b/src/ocha_stratus/email/listmonk.py
@@ -1,0 +1,118 @@
+"""
+Listmonk transactional email helpers.
+
+Listmonk API: https://listmonk.app/docs/apis/transactional/
+
+Delivery mechanics (from listmonk source, internal/messenger/email/email.go):
+    Listmonk's /api/tx endpoint handles To, Cc, and Bcc headers differently:
+
+    - To header:  COSMETIC ONLY. Sets the display header in the recipient's
+      email client but does NOT add addresses to the SMTP envelope. To
+      actually deliver to "To" recipients, they must be listed in
+      subscriber_emails (with subscriber_mode="external").
+
+    - Cc header:  DELIVERY + DISPLAY. Listmonk parses the Cc header, adds
+      addresses to the SMTP envelope (em.Cc), and then removes the header
+      (smtppool re-adds it). Recipients see Cc in their client AND receive
+      the email.
+
+    - Bcc header: DELIVERY ONLY. Same as Cc -- parsed into SMTP envelope
+      (em.Bcc) and removed from headers. Recipients receive the email but
+      are not visible to other recipients.
+
+    Therefore, send_transactional() uses subscriber_emails for To recipients
+    and relies on header parsing for Cc/Bcc delivery.
+"""
+
+import os
+
+import requests
+
+BASE_URL = (
+    "https://listmonk-demo-afhcg8e2hde0fxca.eastus2-01.azurewebsites.net/api"
+)
+
+BASE_TRANSACTIONAL_ID = 12  # template set up for transactional emails.
+
+USERNAME = os.getenv("DSCI_LISTMONK_API_USERNAME")
+PASSWORD = os.getenv("DSCI_LISTMONK_API_KEY")
+
+
+def send_transactional(
+    to_emails: list[tuple[str, str]],
+    subject: str,
+    template_id: int = BASE_TRANSACTIONAL_ID,
+    cc_emails: list[tuple[str, str]] = None,
+    bcc_emails: list[tuple[str, str]] = None,
+    data: dict = None,
+):
+    """Send a transactional email via Listmonk to multiple recipients.
+
+    Parameters
+    ----------
+    to_emails : list of (name, email)
+        Required. At least one recipient. Delivered via subscriber_emails
+        (envelope). Displayed in the To header.
+    subject : str
+        Email subject line.
+    template_id : int, optional
+        Listmonk template ID to use. Defaults to BASE_TRANSACTIONAL_ID.
+    cc_emails : list of (name, email), optional
+        CC recipients. Delivered via Cc header (parsed into envelope by
+        Listmonk). Visible to all recipients.
+    bcc_emails : list of (name, email), optional
+        BCC recipients. Delivered via Bcc header (parsed into envelope by
+        Listmonk). Hidden from other recipients.
+    data : dict, optional
+        Template variables accessible as ``{{ .Tx.Data.* }}`` in the
+        Listmonk template.
+
+    Raises
+    ------
+    ValueError
+        If to_emails is empty or not provided.
+    """
+    if not to_emails:
+        raise ValueError("to_emails must contain at least one recipient")
+
+    to_addresses = [email for _, email in to_emails]
+
+    headers = [
+        {"To": ", ".join(f"{name} <{email}>" for name, email in to_emails)}
+    ]
+    if cc_emails:
+        headers.append(
+            {"Cc": ", ".join(f"{name} <{email}>" for name, email in cc_emails)}
+        )
+    if bcc_emails:
+        headers.append(
+            {
+                "Bcc": ", ".join(
+                    f"{name} <{email}>" for name, email in bcc_emails
+                )
+            }
+        )
+
+    payload = {
+        "subscriber_emails": to_addresses,
+        "subscriber_mode": "external",
+        "template_id": template_id,
+        "from_email": "OCHA Data Science <ocha-datascience@un.org>",
+        "content_type": "html",
+        "subject": subject,
+        "data": data or {},
+        "headers": headers,
+    }
+
+    r = requests.post(
+        f"{BASE_URL}/tx",
+        auth=(USERNAME, PASSWORD),
+        json=payload,
+    )
+    if not r.ok:
+        print("Status:", r.status_code)
+        print("Response text:", r.text)
+        print("Payload sent:", payload)
+
+    r.raise_for_status()
+    return r.json()


### PR DESCRIPTION
## Summary

- Adds `ocha_stratus.email.listmonk` module with `send_transactional()` for sending transactional (non-campaign) emails via Listmonk
- Adds `requests` as a dependency

## Context

This is for **transactional emails only** — not campaigns. The key design:

- **To/CC are visible** to all recipients, so everyone can see who received the email
- **BCC is supported** — we can use our `ocha-datascience@un.org` address as a BCC recipient to maintain a ledger/log, since Listmonk does not log transactional (non-campaign) emails on its side

Currently in use in the AFG drought monitoring repo: https://github.com/OCHA-DAP/ds-aa-afg-drought/blob/2026-monitoring-w2/src/monitoring_2026/listmonk.py

## Limitation - next steps

It's worth noting this fixes 1 of the issues we had, but the other issue is still unexplored - shown below

- [x]  issue 1: w/ AFG emails which turned out to be that `to_emails` didn't receive the emal but cc_emails did... this also adds the bcc functionality and using it as a log/ledger idea

- [ ] issue 2: w/ CADC emails where it seems somehow email displays were truncated potentially due to line breaks. Unclear if this would have caused emails not to get sent or just messed up display names. I am sure the original Mar CADC emails also had the issue that got fixed above so it's a good thing we manually resent anyways

So we could either merge this w/ word of caution about using it or wait until we have clarity/ a fix for issue2

thanks to @t-downing for the base code and setting up the transactional email template. This should fix some of the issues we had in March monitoring moment emails